### PR TITLE
patch: allow skipping auto scale

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const opt = require('adnn/opt')
 
 module.exports = class Autoencoder {
   constructor (params) {
-    this.scale = params.scale || true
+    this.scale = params.scale ?? true
 
     let encoderLayers = []
     let decoderLayers = []


### PR DESCRIPTION
The previous implementation will always do auto scale, which will not work without training (fit) at least once